### PR TITLE
Ability to define custom import paths for protobufs.

### DIFF
--- a/cmake/protobuf-generate-cpp.cmake
+++ b/cmake/protobuf-generate-cpp.cmake
@@ -33,6 +33,13 @@ function(PROTOBUF_CATKIN_GENERATE_CPP SRCS HDRS)
     set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
   endif()
 
+  # Add custom protobuf include directories
+  if(PROTOBUF_EXPORT_PATH)
+    foreach(PBEP ${PROTOBUF_EXPORT_PATH})
+      list(APPEND _protobuf_include_path -I ${PBEP})
+    endforeach()
+  endif()
+
   set(${SRCS})
   set(${HDRS})
   foreach(FIL ${ARGN})


### PR DESCRIPTION
Now proto definitions for nested use in other packages can be exported from a catkin package by CFG-EXTRing the proto folder to PROTOBUF_EXPORT_PATH. 
