### PR TITLE
Eval devel space at export time.

### DIFF
--- a/cmake/protobuf-generate-cpp.cmake.in
+++ b/cmake/protobuf-generate-cpp.cmake.in
@@ -52,7 +52,7 @@ function(PROTOBUF_CATKIN_GENERATE_CPP SRCS HDRS)
     add_custom_command(
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.cc"
              "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
-      COMMAND  "${CATKIN_DEVEL_PREFIX}/bin/protoc"
+      COMMAND  "@CATKIN_DEVEL_PREFIX@/bin/protoc"
       ARGS --cpp_out  ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
       DEPENDS ${ABS_FIL}
       COMMENT "Running C++ protocol buffer compiler on ${FIL}"


### PR DESCRIPTION
This way catkin can also build this in an isolated devel - space.