### PR TITLE
Added new, improved proto cpp generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,34 @@ protobuf_catkin
 ===============
 
 A catkin wrapper for Google protocol buffers
+
+## Usage
+In your `CMakeLists.txt`, call the protobuf compiler:
+
+```cmake
+set(PROTO_DEFNS proto/path-to-my-protos/my-proto.proto)
+set(${BASE_PATH} "proto")
+PROTOBUF_CATKIN_GENERATE_CPP2(${BASE_PATH} PROTO_SRCS PROTO_HDRS ${PROTO_DEFNS}) 
+
+...
+
+cs_add_library(${PROJECT_NAME} src/my-source-files.cc
+                               ${PROTO_SRCS}
+                               ${PROTO_HDRS})
+```
+where `BASE_PATH` is the base path to the folder containing all protobuf definitions (in this example, the base path is `proto`).
+
+This will generate C++ codes for the protos given by `PROTO_DEFNS`.
+The C++ files will be generated under `catkin_wsbuild/${PROJECT_NAME}/compiled_proto`.
+The structure within this folder mirrors the structure of the source definitions (within `BASE_PATH`).
+
+From the compiled C++ files, the generated headers (`*.pb.h`) are installed into `catkin_ws/devel/include`, again keeping the folder structure from within `BASE_PATH`.
+The `*.proto` definition files are installed into `catkin_ws/devel/share/proto` so that they can be used by other packages.
+
+The example code above would generate the following files:
+- `catkin_ws/build/${PROJECT_NAME}/compiled_proto/path-to-my-protos/my-proto.pb.cc`
+- `catkin_ws/build/${PROJECT_NAME}/compiled_proto/path-to-my-protos/my-proto.pb.h`
+- `catkin_ws/devel/include/path-to-my-protos/my-proto.pb.h`
+- `catkin_ws/devel/share/proto/path-to-my-protos/my-proto.pb.h`
+
+The protobuf definitions can then be used with `#include <path-to-my-protos/my-proto.pb.h` in C++ or with `import "path-to-my-protos/my-proto.proto";` in other protobuf definition files.

--- a/cmake/protobuf-generate-cpp.cmake.in
+++ b/cmake/protobuf-generate-cpp.cmake.in
@@ -15,6 +15,8 @@
 
 # Legacy function for backwards compatibility.
 function(PROTOBUF_CATKIN_GENERATE_CPP SRCS HDRS)
+  message(WARNING "PROTOBUF_CATKIN_GENERATE_CPP is deprecated. Please use PROTOBUF_CATKIN_GENERATE_CPP2 instead. Check the Readme for details.")
+
   if(NOT ARGN)
     message(SEND_ERROR "Error: PROTOBUF_CATKIN_GENERATE_CPP() called without any proto files")
     return()

--- a/cmake/protobuf-generate-cpp.cmake.in
+++ b/cmake/protobuf-generate-cpp.cmake.in
@@ -13,6 +13,7 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
+# Legacy function for backwards compatibility.
 function(PROTOBUF_CATKIN_GENERATE_CPP SRCS HDRS)
   if(NOT ARGN)
     message(SEND_ERROR "Error: PROTOBUF_CATKIN_GENERATE_CPP() called without any proto files")
@@ -54,6 +55,75 @@ function(PROTOBUF_CATKIN_GENERATE_CPP SRCS HDRS)
              "${CMAKE_CURRENT_BINARY_DIR}/${FIL_WE}.pb.h"
       COMMAND  "@CATKIN_DEVEL_PREFIX@/bin/protoc"
       ARGS --cpp_out  ${CMAKE_CURRENT_BINARY_DIR} ${_protobuf_include_path} ${ABS_FIL}
+      DEPENDS ${ABS_FIL}
+      COMMENT "Running C++ protocol buffer compiler on ${FIL}"
+      VERBATIM )
+  endforeach()
+
+  set_source_files_properties(${${SRCS}} ${${HDRS}} PROPERTIES GENERATED TRUE)
+  set(${SRCS} ${${SRCS}} PARENT_SCOPE)
+  set(${HDRS} ${${HDRS}} PARENT_SCOPE)
+endfunction()
+
+function(PROTOBUF_CATKIN_GENERATE_CPP2 BASE_PATH SRCS HDRS)
+  if(NOT ARGN)
+    message(SEND_ERROR "Error: PROTOBUF_CATKIN_GENERATE_CPP2() called without any proto files")
+    return()
+  endif(NOT ARGN)
+
+  list(APPEND _protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR}/${BASE_PATH})
+
+  set(${SRCS})
+  set(${HDRS})
+
+  # Folder where the proto sources are generated in. This should resolve to
+  # "build/project_name/compiled_proto".
+  set(COMPILED_PROTO_FOLDER "${CMAKE_CURRENT_BINARY_DIR}/compiled_proto")
+  file(MAKE_DIRECTORY ${COMPILED_PROTO_FOLDER})
+
+  # Folder where the generated headers are installed to. This should resolve to
+  # "devel/include".
+  set(PROTO_GENERATED_HEADERS_INSTALL_DIR
+      ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
+  file(MAKE_DIRECTORY ${PROTO_GENERATED_HEADERS_INSTALL_DIR})
+
+  # Folder where the proto files are placed, so that they can be used in other
+  # proto definitions. This should resolve to "devel/share/proto".
+  set(PROTO_FILE_INSTALL_DIR 
+      ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_SHARE_DESTINATION}/proto)
+  file(MAKE_DIRECTORY ${PROTO_FILE_INSTALL_DIR})
+  list(APPEND _protobuf_include_path -I ${PROTO_FILE_INSTALL_DIR})
+
+  foreach(FIL ${ARGN})
+    get_filename_component(ABS_FIL ${FIL} ABSOLUTE)
+    get_filename_component(FIL_WE ${FIL} NAME_WE)
+    get_filename_component(FIL_REL_DIR ${FIL} DIRECTORY)
+
+    # FIL_REL_DIR contains the path to the proto file, starting inside
+    # BASE_PATH. E.g., for base path "proto" and file 
+    # "proto/project/definitions.proto", FIL_REL_DIR would be "project".
+    string(REGEX REPLACE "${BASE_PATH}/?" "" FIL_REL_DIR ${FIL_REL_DIR})
+    set(OUTPUT_FOLDER ${COMPILED_PROTO_FOLDER}/${FIL_REL_DIR})
+    set(OUTPUT_FOLDER_BASE ${COMPILED_PROTO_FOLDER})
+    file(MAKE_DIRECTORY ${OUTPUT_FOLDER})
+    set(OUTPUT_BASE_FILE_NAME "${OUTPUT_FOLDER}/${FIL_WE}")
+
+    list(APPEND ${SRCS} "${OUTPUT_BASE_FILE_NAME}.pb.cc")
+    list(APPEND ${HDRS} "${OUTPUT_BASE_FILE_NAME}.pb.h")
+
+    add_custom_command(
+      OUTPUT "${OUTPUT_BASE_FILE_NAME}.pb.cc"
+             "${OUTPUT_BASE_FILE_NAME}.pb.h"
+             "${PROTO_GENERATED_HEADERS_INSTALL_DIR}/${FIL_WE}.pb.h"
+             "${PROTO_FILE_INSTALL_DIR}/${PROJECT_NAME}/${FIL_WE}.proto"
+      COMMAND  "${CATKIN_DEVEL_PREFIX}/bin/protoc"
+      ARGS --cpp_out  ${OUTPUT_FOLDER_BASE} ${_protobuf_include_path} ${ABS_FIL}
+      COMMAND ${CMAKE_COMMAND} -E copy
+              "${OUTPUT_BASE_FILE_NAME}.pb.h"
+              "${PROTO_GENERATED_HEADERS_INSTALL_DIR}/${FIL_REL_DIR}/${FIL_WE}.pb.h"
+      COMMAND ${CMAKE_COMMAND} -E copy
+              ${ABS_FIL}
+              "${PROTO_FILE_INSTALL_DIR}/${FIL_REL_DIR}/${FIL_WE}.proto"
       DEPENDS ${ABS_FIL}
       COMMENT "Running C++ protocol buffer compiler on ${FIL}"
       VERBATIM )


### PR DESCRIPTION
New, improved proto generate function. This should get rid of the old extra cfg files to make proto definitions available to other packages.

Functionality of the new function:
- Generate proto cpp src and header in `build/project_name/compiled_proto`
- Install cpp proto headers (`*.pb.h`) to `devel/include`.
- Install `*.proto` files to `devel/share/proto` to be used from other protos.
- No extra stuff is needed in project CMakeLists to export proto files.
- The old function is kept to stay compatible with other users of protobuf_catkin.

File structure within `project/proto` is preserved, e.g., the file `catkin_ws/src/my_package/proto/my-folder/my-proto.proto` generates the following files inside your catkin ws:
- `build/my_package/compiled_proto/my-folder/my-proto.pb.h`
- `build/my_package/compiled_proto/my-folder/my-proto.pb.cc`
- `devel/include/my-folder/my-proto.pb.h`
- `devel/share/my-folder/my-proto.proto`
It can be used with:
- Proto: `import "my-folder/my-proto.proto"`
- C++: `#include "my-folder/my-proto.pb.h"`

@schneith wdyt?