### PR TITLE
Added search path such that protoc is found from other, merged workspaces

### DIFF
--- a/cmake/protobuf-generate-cpp.cmake.in
+++ b/cmake/protobuf-generate-cpp.cmake.in
@@ -14,13 +14,16 @@
 #  License text for the above reference.)
 
 function(_find_protobuf_compiler)
+  # get first directory that points into devel space of protobuf catkin workspace
+  list (GET protobuf_catkin_INCLUDE_DIRS 0 first_protobuf_catkin_include_dir)
+
   set(PROTOBUF_COMPILER_CANDIDATES
       "${CATKIN_DEVEL_PREFIX}/bin/protoc"	       # only works from same workspace 
 						       # (DEVEL_PREFIX evaluates to workspace that is built, 
 						       # not workspace where protobuf_catkin is)
       "/opt/ros/$ENV{ROS_DISTRO}/bin/protoc"
-      "${protobuf_catkin_INCLUDE_DIRS}/../bin/protoc"  # if protoc is needed from another merged workspace, 
-						       # use path that leads to package workspace
+      "${first_protobuf_catkin_include_dir}/../bin/protoc"  # if protoc is needed from another merged workspace, 
+                                                            # use path that leads to package workspace
   )
 
   foreach(candidate ${PROTOBUF_COMPILER_CANDIDATES})

--- a/cmake/protobuf-generate-cpp.cmake.in
+++ b/cmake/protobuf-generate-cpp.cmake.in
@@ -15,9 +15,14 @@
 
 function(_find_protobuf_compiler)
   set(PROTOBUF_COMPILER_CANDIDATES
-      "${CATKIN_DEVEL_PREFIX}/bin/protoc"
+      "${CATKIN_DEVEL_PREFIX}/bin/protoc"	       # only works from same workspace 
+						       # (DEVEL_PREFIX evaluates to workspace that is built, 
+						       # not workspace where protobuf_catkin is)
       "/opt/ros/$ENV{ROS_DISTRO}/bin/protoc"
+      "${protobuf_catkin_INCLUDE_DIRS}/../bin/protoc"  # if protoc is needed from another merged workspace, 
+						       # use path that leads to package workspace
   )
+
   foreach(candidate ${PROTOBUF_COMPILER_CANDIDATES})
     if(EXISTS ${candidate})
       message(STATUS "Found protobuf compiler: ${candidate}")


### PR DESCRIPTION
Issue:
protoc is not found when used from a catkin package in another (merged) workspace than the one where protobuf_catkin is located.

Reason:
${CATKIN_DEVEL_PREFIX} evaluates to the workspace that is currently built, but not necessarily the one where protobuf_catkin is located.

Solution:
Added search path in cmake file that evaluates to a path inside the workspace where protobuf_catkin is located and traverse from there.
Old search paths are still untouched, so should have minimal impact.