### PR TITLE
Find exported protobufs from other catkin packages in PROTOBUF_CATKIN_GENERATE_CPP2

### DIFF
--- a/cmake/protobuf-generate-cpp.cmake.in
+++ b/cmake/protobuf-generate-cpp.cmake.in
@@ -142,6 +142,13 @@ function(PROTOBUF_CATKIN_GENERATE_CPP2 BASE_PATH SRCS HDRS)
     endif()
   endforeach()
 
+  # Add custom protobuf include directories
+  if(PROTOBUF_EXPORT_PATH)
+    foreach(PBEP ${PROTOBUF_EXPORT_PATH})
+      list(APPEND _protobuf_include_path -I ${PBEP})
+    endforeach()
+  endif()
+
   set(PYTHON_PROTOC_ARG_VALUE "")
   set(PYTHON_PROTOC_ARG_FLAGS "")
   set(PROTOC_PYTHON_COMMENT "")


### PR DESCRIPTION
Protobufs exported by other catkin packages were not searched for in `PROTOBUF_CATKIN_GENERATE_CPP2` as they were described in the [wiki](https://github.com/ethz-asl/protobuf_catkin/wiki) and searched for in `PROTOBUF_CATKIN_GENERATE_CPP` [here](https://github.com/ethz-asl/protobuf_catkin/blob/master/cmake/protobuf-generate-cpp.cmake.in#L70).

I assume that I only ran into a problem with this because I use a `linked` workspace.